### PR TITLE
Exclude files without blob_url when getting PR blobs

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -14701,8 +14701,8 @@ async function getPrFilesWithBlobSize(pullRequestNumber) {
         })
         : data;
     const prFilesWithBlobSize = await Promise.all(files
-        // Cannot get blobs for files without sha (e.g. happens when only changing a permission bit on the file)
-        .filter(file => file.sha != null)
+        // Cannot get blobs for files without sha (e.g. happens when only changing a permission bit on the file) or without blob_url (e.g. submodules)
+        .filter(file => file.sha != null && file.blob_url != null)
         .map(async (file) => {
         const { filename, sha, patch } = file;
         const { data: blob } = await octokit.rest.git.getBlob({

--- a/src/index.ts
+++ b/src/index.ts
@@ -199,8 +199,8 @@ async function getPrFilesWithBlobSize(pullRequestNumber: number) {
 
   const prFilesWithBlobSize = await Promise.all(
     files
-      // Cannot get blobs for files without sha (e.g. happens when only changing a permission bit on the file)
-      .filter(file => file.sha != null)
+      // Cannot get blobs for files without sha (e.g. happens when only changing a permission bit on the file) or without blob_url (e.g. submodules)
+      .filter(file => file.sha != null && file.blob_url != null)
       .map(async file => {
         const {filename, sha, patch} = file;
         const {data: blob} = await octokit.rest.git.getBlob({


### PR DESCRIPTION
Overwrites #156 to not have all the changes in the dist folder.

This pull request includes a change in the `getPrFilesWithBlobSize` function in `src/index.ts`. To ensure that we only fetch blobs for files that actually have a blob.

Fixes #144