### PR TITLE
Support pull_request_target

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -14565,7 +14565,7 @@ async function run() {
     const labelName = core.getInput('labelName');
     const labelColor = core.getInput('labelColor');
     await getOrCreateLfsWarningLabel(labelName, labelColor);
-    if (event_type === 'pull_request') {
+    if (event_type === 'pull_request' || event_type === 'pull_request_target') {
         const pullRequestNumber = (_a = context.payload.pull_request) === null || _a === void 0 ? void 0 : _a.number;
         if (pullRequestNumber === undefined) {
             throw new Error('Could not get PR number');

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ async function run() {
 
   await getOrCreateLfsWarningLabel(labelName, labelColor);
 
-  if (event_type === 'pull_request') {
+  if (event_type === 'pull_request' || event_type === 'pull_request_target') {
     const pullRequestNumber = context.payload.pull_request?.number;
 
     if (pullRequestNumber === undefined) {


### PR DESCRIPTION
This pull request modifies the code in `src/index.ts` to handle both `pull_request` and `pull_request_target` events. The changes ensure that the pull request number is obtained correctly regardless of the event type.

Main code modification:

* <a href="diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L35-R35">`src/index.ts`</a>: Modified the code to handle both `pull_request` and `pull_request_target` events, ensuring that the pull request number is obtained correctly.

Fixes #150